### PR TITLE
Bump to React && ReactDOM 0.14.3. Bump package version to 1.1.0.

### DIFF
--- a/dist/LazyLoad.js
+++ b/dist/LazyLoad.js
@@ -1,4 +1,5 @@
 var React = require('react'),
+    ReactDOM = require('react-dom'),
     ClassNames = require('classnames'),
 
     LazyLoad = React.createClass({
@@ -13,11 +14,11 @@ var React = require('react'),
             };
         },
         handleScroll: function() {
-            var bounds = this.getDOMNode().getBoundingClientRect(),
+            var bounds = ReactDOM.findDOMNode(this).getBoundingClientRect(),
                 scrollTop = window.pageYOffset,
                 top = bounds.top + scrollTop,
                 height = bounds.bottom - bounds.top,
-                adLoadBuffer = this.props.adLoadBuffer || 200;  
+                adLoadBuffer = this.props.adLoadBuffer || 200;
 
             if(top === 0 || (top - adLoadBuffer <= (scrollTop + window.innerHeight) && (top + height) > scrollTop)){
                 this.setState({visible: true});
@@ -51,7 +52,7 @@ var React = require('react'),
                 });
 
             return (
-                React.createElement("div", {style: preloadHeight, className: classes}, 
+                React.createElement("div", {style: preloadHeight, className: classes},
                     this.state.visible ? this.props.children : ''
                 )
             );

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,7 +9,8 @@
 <div id='test'>test</div>
     <div id="content"></div>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/JSXTransformer.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/react-with-addons.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.3/react-with-addons.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.3/react-dom.js"></script>
 
     <script type="text/jsx">
 
@@ -20,11 +21,11 @@
             },
             getInitialState: function() {
                 return {
-                    visible: false 
+                    visible: false
                 };
             },
             handleScroll: function() {
-                var bounds = this.getDOMNode().getBoundingClientRect(),
+                var bounds = ReactDOM.findDOMNode(this).getBoundingClientRect(),
                     scrollTop = window.pageYOffset,
                     top = bounds.top + scrollTop,
                     height = bounds.bottom - bounds.top;
@@ -45,14 +46,10 @@
             },
             render: function () {
                 var renderEl = '',
-                    cx = React.addons.classSet,
                     preloadHeight = {
                         height: this.props.height
                     },
-                    classes = cx({
-                        'lazy-load': true,
-                        'lazy-load-visible': this.state.visible
-                    });
+                    classes = 'lazy-load ' + (this.state.visible) ? 'lazy-load-visible' : '';
 
                 return (
                     <div style={preloadHeight} className={classes}>
@@ -90,7 +87,7 @@
             }
         });
 
-        React.render(<Application />, document.getElementById('content'));
+        ReactDOM.render(<Application />, document.getElementById('content'));
     </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazy-load",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Simple lazy loading component built with react",
   "main": "dist/LazyLoad.js",
   "files": [
@@ -27,7 +27,8 @@
     "classnames": "^2.1.2"
   },
   "peerDependencies": {
-    "react": "^0.13.x||^0.14.0"
+    "react": "0.14.3",
+    "react-dom": "0.14.3"
   },
   "devDependencies": {
     "react-tools": "^0.13.0"


### PR DESCRIPTION
This PR intends to make LazyLoad compatible with react 0.14.
I didn't found a way to make a fallback for 0.13.
